### PR TITLE
Add .pth and data/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Neural Network path
+*.pth
+
+# Data folders
+data/


### PR DESCRIPTION
This pull request adds the .pth and data/ folders to the .gitignore file. This ensures that these folders are not tracked by Git and will not be included in future commits.